### PR TITLE
fix(http): do not attempt to autolink if previous character is often found in markup

### DIFF
--- a/dev/lib/syntax.js
+++ b/dev/lib/syntax.js
@@ -595,7 +595,7 @@ function previousWww(code) {
 
 /** @type {Previous} */
 function previousHttp(code) {
-  return code === codes.eof || !asciiAlpha(code)
+  return code === codes.eof || (!asciiAlpha(code) && code !== codes.equalsTo && code !== codes.greaterThan)
 }
 
 /** @type {Previous} */

--- a/dev/lib/syntax.js
+++ b/dev/lib/syntax.js
@@ -595,12 +595,15 @@ function previousWww(code) {
 
 /** @type {Previous} */
 function previousHttp(code) {
-  return code === codes.eof || (!asciiAlpha(code) && code !== codes.equalsTo && code !== codes.greaterThan)
+  return (
+    code === codes.eof ||
+    (!asciiAlpha(code) && code !== codes.equalsTo && code !== codes.greaterThan)
+  )
 }
 
 /** @type {Previous} */
 function previousEmail(code) {
-  return code !== codes.slash && previousHttp(code)
+  return code !== codes.slash && (code === codes.eof || !asciiAlpha(code))
 }
 
 /**

--- a/test/fixtures/previous.comment.html
+++ b/test/fixtures/previous.comment.html
@@ -8,6 +8,8 @@
 <p>Can start after asterisk *<a href="https://a.b">https://a.b</a>.</p>
 <p>Can start after underscore *_<a href="https://a.b">https://a.b</a>.</p>
 <p>Can start after tilde ~<a href="https://a.b">https://a.b</a>.</p>
+<p>Cannot start after greater than >http://www.example.com</p>
+<p>Cannot start after equals sign =http://www.example.com</p>
 <h1>www</h1>
 <p><a href="http://www.a.b">www.a.b</a> can start after EOF</p>
 <p>Can start after EOL:<br>

--- a/test/fixtures/previous.comment.md
+++ b/test/fixtures/previous.comment.md
@@ -17,6 +17,10 @@ Can start after underscore *_https://a.b.
 
 Can start after tilde ~https://a.b.
 
+Cannot start after greater than >http://www.example.com
+
+Cannot start after equals sign =http://www.example.com
+
 # www
 
 www.a.b can start after EOF


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

- added a check to `previousHttp` to avoid `>` and `=`
- made sure that the previous check does not apply to `previousEmail`

<!--do not edit: pr-->

see https://github.com/micromark/micromark-extension-gfm/pull/4

Porting the tests is a bit tricky, as they depend on the interplay with raw HTML parsing, so I'm only adding minimal tests here.