### PR TITLE
Distinguished between email addresses and ActivityPub identifiers

### DIFF
--- a/dev/lib/syntax.js
+++ b/dev/lib/syntax.js
@@ -112,6 +112,7 @@ function tokenizeEmailAutolink(effects, ok, nok) {
    */
   function start(code) {
     if (
+      self.previous === codes.atSign ||
       !gfmAtext(code) ||
       !previousEmail.call(self, self.previous) ||
       previousUnbalanced(self.events)

--- a/test/index.js
+++ b/test/index.js
@@ -137,6 +137,19 @@ test('micromark-extension-gfm-autolink-literal', async function (t) {
   )
 
   await t.test(
+    'should *not* support activitypub identifiers (email)',
+    async function () {
+      assert.equal(
+        micromark('@example@example.com', {
+          extensions: [gfmAutolinkLiteral()],
+          htmlExtensions: [gfmAutolinkLiteralHtml()]
+        }),
+        '<p>@example@example.com</p>'
+      )
+    }
+  )
+
+  await t.test(
     'should *not* support non-ascii characters in a domain (email)',
     async function () {
       assert.equal(


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

ActivityPub identifiers are something like `@example@example.com`, and they are NOT email addresses.

<!--do not edit: pr-->
